### PR TITLE
feat: add underscore route for enterpise-catalogs

### DIFF
--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -10,7 +10,7 @@ from django.conf.urls import url
 from enterprise.api.v1 import views
 
 router = DefaultRouter()  # pylint: disable=invalid-name
-router.register("enterprise_catalogs", views.EnterpriseCustomerCatalogViewSet, 'enterprise-catalogs')
+router.register(r"enterprise[-_]catalogs", views.EnterpriseCustomerCatalogViewSet, 'enterprise-catalogs')
 router.register("enterprise-course-enrollment", views.EnterpriseCourseEnrollmentViewSet, 'enterprise-course-enrollment')
 router.register(
     "licensed-enterprise-course-enrollment",


### PR DESCRIPTION
# Description 
- Add a base dash `-`to use the plugin as enterprise service. This given the ability to work the same like the undersorce `r` route.
Main route:
`/enterprise/api/v1/enterprise_catalogs/`
Clone route:
`/enterprise/api/v1/enterprise-catalogs/`


# Before:
![2022-05-04_10-53](https://user-images.githubusercontent.com/51926076/166721513-dbdf1152-39a3-494b-bd6b-5987837e9c2d.png)
![2022-05-04_10-52](https://user-images.githubusercontent.com/51926076/166721522-3fba1d5c-70f8-4225-9ebc-d344f7cf5197.png)

# After: 
![2022-05-04_11-02](https://user-images.githubusercontent.com/51926076/166722803-84521cca-68cc-4a8d-9c60-7d2ac696a6dd.png)
![2022-05-04_11-03](https://user-images.githubusercontent.com/51926076/166722992-869f4530-fe6b-41d3-b39a-631467d70cc4.png)
